### PR TITLE
Add OAuth login

### DIFF
--- a/API/config/database_indexes_config.go
+++ b/API/config/database_indexes_config.go
@@ -10,3 +10,5 @@ const IdxCommentsUserID = `CREATE INDEX IF NOT EXISTS idx_comments_user_id ON co
 const IdxReactionsUserID = `CREATE INDEX IF NOT EXISTS idx_reactions_user_id ON reactions(user_id);`
 const IdxReactionsPostID = `CREATE INDEX IF NOT EXISTS idx_reactions_post_id ON reactions(post_id);`
 const IdxReactionsCommentID = `CREATE INDEX IF NOT EXISTS idx_reactions_comment_id ON reactions(comment_id);`
+const IdxUserProvidersUserID = `CREATE INDEX IF NOT EXISTS idx_user_providers_user_id ON user_providers(user_id);`
+const IdxUserProvidersProvider = `CREATE INDEX IF NOT EXISTS idx_user_providers_provider ON user_providers(provider, provider_id);`

--- a/API/config/oauth_config.go
+++ b/API/config/oauth_config.go
@@ -1,0 +1,13 @@
+package config
+
+// OAuth provider endpoints and credentials
+// Replace the placeholders with your actual client IDs and secrets.
+var (
+	GoogleClientID     = "GOOGLE_CLIENT_ID"
+	GoogleClientSecret = "GOOGLE_CLIENT_SECRET"
+	GoogleRedirectURL  = "http://localhost:8080/forum/api/oauth/google/callback"
+
+	GitHubClientID     = "GITHUB_CLIENT_ID"
+	GitHubClientSecret = "GITHUB_CLIENT_SECRET"
+	GitHubRedirectURL  = "http://localhost:8080/forum/api/oauth/github/callback"
+)

--- a/API/config/schema_config.go
+++ b/API/config/schema_config.go
@@ -1,7 +1,5 @@
 package config
 
-import ()
-
 const CreatePostCategoriesTable = `CREATE TABLE IF NOT EXISTS post_categories (
     post_id TEXT NOT NULL,
     category_id INTEGER NOT NULL,
@@ -9,7 +7,6 @@ const CreatePostCategoriesTable = `CREATE TABLE IF NOT EXISTS post_categories (
     FOREIGN KEY (post_id) REFERENCES posts(post_id) ON DELETE CASCADE,
     FOREIGN KEY (category_id) REFERENCES categories(category_id) ON DELETE CASCADE
 );`
-
 
 const CreateUserTable = `CREATE TABLE IF NOT EXISTS user (
             user_id TEXT PRIMARY KEY,
@@ -24,6 +21,15 @@ const CreateUserAuthTable = `CREATE TABLE IF NOT EXISTS user_auth (
             FOREIGN KEY (user_id) REFERENCES user(user_id) ON DELETE CASCADE
         );`
 
+const CreateUserProvidersTable = `CREATE TABLE IF NOT EXISTS user_providers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    provider_id TEXT NOT NULL,
+    UNIQUE(provider, provider_id),
+    FOREIGN KEY (user_id) REFERENCES user(user_id) ON DELETE CASCADE
+);`
+
 const CreateSessionsTable = `CREATE TABLE IF NOT EXISTS sessions (
     user_id TEXT PRIMARY KEY,
     session_id TEXT NOT NULL UNIQUE,
@@ -34,12 +40,11 @@ const CreateSessionsTable = `CREATE TABLE IF NOT EXISTS sessions (
     FOREIGN KEY (user_id) REFERENCES user(user_id) ON DELETE CASCADE
 );`
 
-
 const CreateCategoriesTable = `CREATE TABLE IF NOT EXISTS categories (
             category_id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT NOT NULL UNIQUE CHECK (LENGTH(name) <= 100)
         );`
-		
+
 const CreatePostsTable = `CREATE TABLE IF NOT EXISTS posts (
     post_id TEXT PRIMARY KEY,
     user_id TEXT NOT NULL,
@@ -49,7 +54,6 @@ const CreatePostsTable = `CREATE TABLE IF NOT EXISTS posts (
     updated_at TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES user(user_id) ON DELETE CASCADE
 );`
-
 
 const CreateCommentsTable = `CREATE TABLE IF NOT EXISTS comments (
             comment_id TEXT PRIMARY KEY,

--- a/API/handlers/auth_handlers.go
+++ b/API/handlers/auth_handlers.go
@@ -1,11 +1,16 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 
+	"forum/config"
 	"forum/models"
 	"forum/repository"
 	"forum/utils"
@@ -15,6 +20,7 @@ import (
 type AuthHandler struct {
 	UserRepo    *repository.UserRepository
 	SessionRepo *repository.SessionRepository
+	oauthStates map[string]string
 }
 
 // NewAuthHandler creates a new AuthHandler
@@ -22,6 +28,7 @@ func NewAuthHandler(userRepo *repository.UserRepository, sessionRepo *repository
 	return &AuthHandler{
 		UserRepo:    userRepo,
 		SessionRepo: sessionRepo,
+		oauthStates: make(map[string]string),
 	}
 }
 
@@ -134,7 +141,7 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	csrfToken := utils.GenerateCSRFToken()	
+	csrfToken := utils.GenerateCSRFToken()
 
 	// Create a new session
 	log.Println("Creating session for user:", user.ID)
@@ -147,15 +154,14 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 
 	// Set cookie
 	http.SetCookie(w, &http.Cookie{
-    Name:     "session_id",
-    Value:    session.SessionID,
-    Path:     "/",
-    Expires:  session.ExpiresAt,
-    HttpOnly: true,
-    Secure:   false,
-    SameSite: http.SameSiteLaxMode, // Change from None to Lax for localhost
-})
-
+		Name:     "session_id",
+		Value:    session.SessionID,
+		Path:     "/",
+		Expires:  session.ExpiresAt,
+		HttpOnly: true,
+		Secure:   false,
+		SameSite: http.SameSiteLaxMode, // Change from None to Lax for localhost
+	})
 
 	// Return response
 	w.Header().Set("Content-Type", "application/json")
@@ -224,4 +230,202 @@ func (h *AuthHandler) VerifySession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	utils.JSONResponse(w, user, http.StatusOK)
+}
+
+// GoogleLogin starts the Google OAuth flow
+func (h *AuthHandler) GoogleLogin(w http.ResponseWriter, r *http.Request) {
+	state := utils.GenerateCSRFToken()
+	h.oauthStates[state] = "google"
+	authURL := fmt.Sprintf("https://accounts.google.com/o/oauth2/v2/auth?client_id=%s&redirect_uri=%s&response_type=code&scope=openid%%20email%%20profile&state=%s",
+		url.QueryEscape(config.GoogleClientID), url.QueryEscape(config.GoogleRedirectURL), state)
+	http.Redirect(w, r, authURL, http.StatusFound)
+}
+
+// GoogleCallback completes the Google OAuth flow
+func (h *AuthHandler) GoogleCallback(w http.ResponseWriter, r *http.Request) {
+	state := r.URL.Query().Get("state")
+	if h.oauthStates[state] != "google" {
+		http.Error(w, "invalid state", http.StatusBadRequest)
+		return
+	}
+	delete(h.oauthStates, state)
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		http.Error(w, "code required", http.StatusBadRequest)
+		return
+	}
+	vals := url.Values{}
+	vals.Set("client_id", config.GoogleClientID)
+	vals.Set("client_secret", config.GoogleClientSecret)
+	vals.Set("code", code)
+	vals.Set("grant_type", "authorization_code")
+	vals.Set("redirect_uri", config.GoogleRedirectURL)
+
+	resp, err := http.PostForm("https://oauth2.googleapis.com/token", vals)
+	if err != nil {
+		http.Error(w, "token exchange failed", http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var tok struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(body, &tok)
+
+	req, _ := http.NewRequest("GET", "https://www.googleapis.com/oauth2/v3/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	uResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		http.Error(w, "failed userinfo", http.StatusInternalServerError)
+		return
+	}
+	defer uResp.Body.Close()
+	data, _ := io.ReadAll(uResp.Body)
+	var info struct {
+		Sub   string `json:"sub"`
+		Email string `json:"email"`
+		Name  string `json:"name"`
+	}
+	json.Unmarshal(data, &info)
+
+	h.handleOAuthLogin(w, r, "google", info.Sub, info.Email, info.Name)
+}
+
+// GitHubLogin starts the GitHub OAuth flow
+func (h *AuthHandler) GitHubLogin(w http.ResponseWriter, r *http.Request) {
+	state := utils.GenerateCSRFToken()
+	h.oauthStates[state] = "github"
+	authURL := fmt.Sprintf("https://github.com/login/oauth/authorize?client_id=%s&redirect_uri=%s&scope=user:email&state=%s",
+		url.QueryEscape(config.GitHubClientID), url.QueryEscape(config.GitHubRedirectURL), state)
+	http.Redirect(w, r, authURL, http.StatusFound)
+}
+
+// GitHubCallback completes the GitHub OAuth flow
+func (h *AuthHandler) GitHubCallback(w http.ResponseWriter, r *http.Request) {
+	state := r.URL.Query().Get("state")
+	if h.oauthStates[state] != "github" {
+		http.Error(w, "invalid state", http.StatusBadRequest)
+		return
+	}
+	delete(h.oauthStates, state)
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		http.Error(w, "code required", http.StatusBadRequest)
+		return
+	}
+
+	vals := url.Values{}
+	vals.Set("client_id", config.GitHubClientID)
+	vals.Set("client_secret", config.GitHubClientSecret)
+	vals.Set("code", code)
+	vals.Set("redirect_uri", config.GitHubRedirectURL)
+
+	req, _ := http.NewRequest("POST", "https://github.com/login/oauth/access_token", bytes.NewBufferString(vals.Encode()))
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		http.Error(w, "token exchange failed", http.StatusInternalServerError)
+		return
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var tok struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.Unmarshal(body, &tok)
+
+	uReq, _ := http.NewRequest("GET", "https://api.github.com/user", nil)
+	uReq.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	uReq.Header.Set("Accept", "application/vnd.github.v3+json")
+	uResp, err := http.DefaultClient.Do(uReq)
+	if err != nil {
+		http.Error(w, "failed userinfo", http.StatusInternalServerError)
+		return
+	}
+	defer uResp.Body.Close()
+	data, _ := io.ReadAll(uResp.Body)
+	var info struct {
+		ID    int    `json:"id"`
+		Email string `json:"email"`
+		Login string `json:"login"`
+	}
+	json.Unmarshal(data, &info)
+
+	if info.Email == "" {
+		// fetch emails endpoint
+		emReq, _ := http.NewRequest("GET", "https://api.github.com/user/emails", nil)
+		emReq.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+		emReq.Header.Set("Accept", "application/vnd.github.v3+json")
+		emResp, err := http.DefaultClient.Do(emReq)
+		if err == nil {
+			defer emResp.Body.Close()
+			emData, _ := io.ReadAll(emResp.Body)
+			var emails []struct {
+				Email   string `json:"email"`
+				Primary bool   `json:"primary"`
+			}
+			json.Unmarshal(emData, &emails)
+			for _, e := range emails {
+				if e.Primary {
+					info.Email = e.Email
+					break
+				}
+			}
+		}
+	}
+
+	h.handleOAuthLogin(w, r, "github", fmt.Sprint(info.ID), info.Email, info.Login)
+}
+
+// handleOAuthLogin links or creates users based on provider info
+func (h *AuthHandler) handleOAuthLogin(w http.ResponseWriter, r *http.Request, provider, providerID, email, name string) {
+	if email == "" {
+		http.Error(w, "email not provided", http.StatusBadRequest)
+		return
+	}
+
+	user, err := h.UserRepo.GetByProvider(provider, providerID)
+	if err == repository.ErrUserNotFound {
+		existing, err2 := h.UserRepo.GetByEmail(strings.ToLower(email))
+		if err2 == nil {
+			h.UserRepo.LinkProvider(existing.ID, provider, providerID)
+			user = existing
+		} else if err2 == repository.ErrUserNotFound {
+			username := name
+			if username == "" {
+				username = strings.Split(email, "@")[0]
+			}
+			user, err = h.UserRepo.CreateWithProvider(username, strings.ToLower(email), provider, providerID)
+			if err != nil {
+				http.Error(w, "failed to create user", http.StatusInternalServerError)
+				return
+			}
+		} else {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+	} else if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	csrf := utils.GenerateCSRFToken()
+	session, err := h.SessionRepo.Create(user.ID, r.RemoteAddr, csrf)
+	if err != nil {
+		http.Error(w, "failed to create session", http.StatusInternalServerError)
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     "session_id",
+		Value:    session.SessionID,
+		Path:     "/",
+		Expires:  session.ExpiresAt,
+		HttpOnly: true,
+		Secure:   false,
+		SameSite: http.SameSiteLaxMode,
+	})
+	resp := models.LoginResponse{User: *user, SessionID: session.SessionID, CSRFToken: csrf}
+	json.NewEncoder(w).Encode(resp)
 }

--- a/API/models/database_model.go
+++ b/API/models/database_model.go
@@ -79,6 +79,7 @@ func createTables(db *sql.DB) error {
 	tableStatements := []string{
 		config.CreateUserTable,
 		config.CreateUserAuthTable,
+		config.CreateUserProvidersTable,
 		config.CreateSessionsTable,
 		config.CreateCategoriesTable,
 		config.CreatePostsTable,
@@ -117,6 +118,8 @@ func createIndexes(db *sql.DB) error {
 		config.IdxReactionsUserID,
 		config.IdxReactionsPostID,
 		config.IdxReactionsCommentID,
+		config.IdxUserProvidersUserID,
+		config.IdxUserProvidersProvider,
 	}
 
 	// Execute each index creation statement

--- a/API/models/user_model.go
+++ b/API/models/user_model.go
@@ -18,6 +18,14 @@ type UserAuth struct {
 	PasswordHash string `json:"-"`
 }
 
+// UserProvider links a user to an OAuth provider account
+type UserProvider struct {
+	ID         int    `json:"id"`
+	UserID     string `json:"user_id"`
+	Provider   string `json:"provider"`
+	ProviderID string `json:"provider_id"`
+}
+
 // UserRegistration is used for registration requests
 type UserRegistration struct {
 	Username string `json:"username" binding:"required"`
@@ -33,12 +41,12 @@ type UserLogin struct {
 
 // Session represents a user session
 type Session struct {
-	UserID     string    `json:"user_id"`
-	SessionID  string    `json:"session_id"`
-	CSRFToken  string    `json:"csrf_token"` // CSRF token for security
-	IPAddress  string    `json:"ip_address"`
-	CreatedAt  time.Time `json:"created_at"`
-	ExpiresAt  time.Time `json:"expires_at"`
+	UserID    string    `json:"user_id"`
+	SessionID string    `json:"session_id"`
+	CSRFToken string    `json:"csrf_token"` // CSRF token for security
+	IPAddress string    `json:"ip_address"`
+	CreatedAt time.Time `json:"created_at"`
+	ExpiresAt time.Time `json:"expires_at"`
 }
 
 // LoginResponse is the response after successful login
@@ -47,10 +55,3 @@ type LoginResponse struct {
 	SessionID string `json:"session_id"`
 	CSRFToken string `json:"csrf_token"`
 }
-
-
-
-
-
-
-

--- a/API/repository/user_repository.go
+++ b/API/repository/user_repository.go
@@ -197,3 +197,59 @@ func (r *UserRepository) Authenticate(login models.UserLogin) (*models.User, err
 
 	return user, nil
 }
+
+// GetByProvider retrieves a user by OAuth provider and ID
+func (r *UserRepository) GetByProvider(provider, providerID string) (*models.User, error) {
+	var user models.User
+	var createdAt time.Time
+	err := r.DB.QueryRow(`SELECT u.user_id, u.username, u.email, u.created_at
+                FROM user u
+                JOIN user_providers up ON u.user_id = up.user_id
+                WHERE up.provider = ? AND up.provider_id = ?`, provider, providerID).
+		Scan(&user.ID, &user.Username, &user.Email, &createdAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrUserNotFound
+		}
+		return nil, err
+	}
+	user.CreatedAt = createdAt
+	return &user, nil
+}
+
+// LinkProvider associates an existing user with an OAuth provider
+func (r *UserRepository) LinkProvider(userID, provider, providerID string) error {
+	_, err := r.DB.Exec(`INSERT OR IGNORE INTO user_providers (user_id, provider, provider_id)
+                VALUES (?, ?, ?)`, userID, provider, providerID)
+	return err
+}
+
+// CreateWithProvider creates a new user without a password and links the provider
+func (r *UserRepository) CreateWithProvider(username, email, provider, providerID string) (*models.User, error) {
+	tx, err := r.DB.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	userID := utils.GenerateUUID()
+	createdAt := time.Now()
+
+	_, err = tx.Exec(`INSERT INTO user (user_id, username, email, created_at) VALUES (?, ?, ?, ?)`,
+		userID, username, email, createdAt)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = tx.Exec(`INSERT INTO user_providers (user_id, provider, provider_id) VALUES (?, ?, ?)`,
+		userID, provider, providerID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return &models.User{ID: userID, Username: username, Email: email, CreatedAt: createdAt}, nil
+}

--- a/API/routes/routes.go
+++ b/API/routes/routes.go
@@ -45,6 +45,10 @@ func SetupRoutes(db *sql.DB) http.Handler {
 	mux.Handle("/forum/api/session/login", corsMiddleware.Handler(http.HandlerFunc(authHandler.Login)))
 	mux.Handle("/forum/api/session/logout", corsMiddleware.Handler(http.HandlerFunc(authHandler.Logout)))
 	mux.Handle("/forum/api/session/verify", corsMiddleware.Handler(http.HandlerFunc(authHandler.VerifySession)))
+	mux.Handle("/forum/api/oauth/google/login", corsMiddleware.Handler(http.HandlerFunc(authHandler.GoogleLogin)))
+	mux.Handle("/forum/api/oauth/google/callback", corsMiddleware.Handler(http.HandlerFunc(authHandler.GoogleCallback)))
+	mux.Handle("/forum/api/oauth/github/login", corsMiddleware.Handler(http.HandlerFunc(authHandler.GitHubLogin)))
+	mux.Handle("/forum/api/oauth/github/callback", corsMiddleware.Handler(http.HandlerFunc(authHandler.GitHubCallback)))
 
 	// Protected routes with CSRF
 	protected := func(h http.Handler) http.Handler {

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A modern, full-stack web forum application featuring secure user authentication,
 ## Features
 
 - User registration, login, and logout
+- Login via Google or GitHub OAuth
 - Create, edit, and delete posts
 - Comment on posts
 - Like/dislike posts and comments
@@ -146,6 +147,11 @@ curl -X POST http://localhost:8080/forum/api/session/login \
   -d '{"email":"test@example.com","password":"password123"}' \
   -c cookies.txt
 ```
+### Login with Google
+Visit: `http://localhost:8080/forum/api/oauth/google/login`
+
+### Login with GitHub
+Visit: `http://localhost:8080/forum/api/oauth/github/login`
 ### Logout
 ```sh
 curl -X POST http://localhost:8080/forum/api/session/logout \

--- a/instructions.md
+++ b/instructions.md
@@ -19,6 +19,12 @@ curl -X POST http://localhost:8080/forum/api/session/login \
   -d '{"email":"test@example.com","password":"password123"}' \
   -c cookies.txt
 
+## Login with Google
+Visit: http://localhost:8080/forum/api/oauth/google/login
+
+## Login with GitHub
+Visit: http://localhost:8080/forum/api/oauth/github/login
+
 ## Logout
 
 curl -X POST http://localhost:8080/forum/api/session/logout \


### PR DESCRIPTION
## Summary
- support Google and GitHub OAuth
- store provider links in new `user_providers` table
- expose OAuth endpoints
- document OAuth usage

## Testing
- `gofmt -w API/config/database_indexes_config.go API/config/schema_config.go API/handlers/auth_handlers.go API/models/database_model.go API/models/user_model.go API/repository/user_repository.go API/routes/routes.go`
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68655a12b42c83248b8b3beff8ae902f